### PR TITLE
Potential fix for code scanning alert no. 196: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -61,6 +61,8 @@ jobs:
   test:
     name: Test on node ${{ matrix.node_version }} and ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
     strategy:
       matrix:
         node_version: ['18.x', '20.x']


### PR DESCRIPTION
Potential fix for [https://github.com/hixio-mh/ai-hub-models/security/code-scanning/196](https://github.com/hixio-mh/ai-hub-models/security/code-scanning/196)

To fix this issue, we should add a `permissions` block with the minimum required privilege to the `test` job. Since the `test` job only checks out the repository and runs Node.js tests, and does not interact with the GitHub API (e.g., uploading artifacts, creating issues, etc.), the least-privilege block is `permissions: contents: read`. 

This should be added directly under the `runs-on` property for the `test` job, as done in the `analyze` job. No changes are needed to the workflow logic—just the addition of:

```yaml
permissions:
  contents: read
```


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
